### PR TITLE
feat: OIDC id-token after device association, Keycloak handoff, and POC wiring

### DIFF
--- a/Sources/IDDigitalSDK/AmplifyInitializer.swift
+++ b/Sources/IDDigitalSDK/AmplifyInitializer.swift
@@ -4,13 +4,17 @@ import AWSCognitoAuthPlugin
 import FactoryKit
 
 final class AmplifyInitializer {
-  static func initialize() async{
-    
-    do {
-      let configService = Container.shared.configService()
-      let configData = try await configService.getConfiguration()
-      
-      let authConfiguration = AuthCategoryConfiguration(
+  static func initialize() async throws {
+    let configService = Container.shared.configService()
+    let configData = try await configService.getConfiguration()
+    let override = Container.shared.cognitoAppClientIdOverride()
+    let appClientId: String? = (configData.cognitoAppClientId.flatMap { $0.isEmpty ? nil : $0 }) ?? (override.flatMap { $0.isEmpty ? nil : $0 })
+    guard let appClientId = appClientId, !appClientId.isEmpty else {
+      print("[IDDigitalSDK] cognitoAppClientId null o vacío en initialize/ (y sin override) — Amplify no se configurará. Liveness puede fallar en dispositivo.")
+      return
+    }
+
+    let authConfiguration = AuthCategoryConfiguration(
         plugins: [
           "awsCognitoAuthPlugin": .object([
             "UserAgent": .string("aws-amplify/swift"),
@@ -29,7 +33,7 @@ final class AmplifyInitializer {
             "CognitoUserPool": .object([
               "Default": .object([
                 "PoolId": .string(configData.cognitoUserPoolId),
-                "AppClientId": .string(configData.cognitoAppClientId),
+                "AppClientId": .string(appClientId),
                 "Region": .string(configData.region)
               ])
             ]),
@@ -50,16 +54,10 @@ final class AmplifyInitializer {
             ])
           ])
         ]
-      )
-      
-      let amplifyConfiguration = AmplifyConfiguration(auth: authConfiguration)
-      
-      try Amplify.add(plugin: AWSCognitoAuthPlugin())
-      try Amplify.configure(amplifyConfiguration)
-      
-      print("Amplify configured successfully from SDK bundle.")
-    } catch {
-      print("Failed to initialize Amplify with error: \(error)")
-    }
+    )
+    let amplifyConfiguration = AmplifyConfiguration(auth: authConfiguration)
+    try Amplify.add(plugin: AWSCognitoAuthPlugin())
+    try Amplify.configure(amplifyConfiguration)
+    print("Amplify configured successfully from SDK bundle.")
   }
 }

--- a/Sources/IDDigitalSDK/DI/Container+Services.swift
+++ b/Sources/IDDigitalSDK/DI/Container+Services.swift
@@ -10,6 +10,10 @@ extension Container {
   var environment: Factory<IDDigitalSDKEnvironment> {
     self { .production }.singleton // Production by default
   }
+  /// Si el backend devuelve cognitoAppClientId null, se usa este valor (p. ej. desde la app demo).
+  var cognitoAppClientIdOverride: Factory<String?> {
+    self { nil }.singleton
+  }
   
   // --- Services ---
   var deviceIdentifierProvider: Factory<DeviceIdentifierProviding> { self { DeviceIdentifierProvider() }.singleton }
@@ -21,6 +25,9 @@ extension Container {
   var deviceAssociationStorage: Factory<DeviceAssociationStoring> { self { DeviceAssociationStorage() }.singleton }
   var configService: Factory<ConfigService> {
     self { ConfigService() }.singleton
+  }
+  var keycloakService: Factory<KeycloakService> {
+    self { KeycloakService() }.singleton
   }
   
   

--- a/Sources/IDDigitalSDK/Data/Models/ConfigData.swift
+++ b/Sources/IDDigitalSDK/Data/Models/ConfigData.swift
@@ -7,7 +7,7 @@
 
 
 struct ConfigData: Decodable {
-    let cognitoAppClientId: String
+    let cognitoAppClientId: String?
     let cognitoUserPoolId: String
     let cognitoIdentityPoolId: String
     let region: String

--- a/Sources/IDDigitalSDK/Data/Models/DeviceAssociation.swift
+++ b/Sources/IDDigitalSDK/Data/Models/DeviceAssociation.swift
@@ -1,5 +1,14 @@
-struct DeviceAssociation: Codable, Sendable {
-  let token: String
-  let document: Document
-  let createdAt: String
+public struct DeviceAssociation: Codable, Sendable {
+  public let token: String
+  public let document: Document
+  public let createdAt: String
+  /// ID token from backend; nil until backend sends it. Use placeholder when persisting if nil.
+  public let idToken: String?
+
+  public init(token: String, document: Document, createdAt: String, idToken: String? = nil) {
+    self.token = token
+    self.document = document
+    self.createdAt = createdAt
+    self.idToken = idToken
+  }
 }

--- a/Sources/IDDigitalSDK/Data/Models/DeviceAssociation.swift
+++ b/Sources/IDDigitalSDK/Data/Models/DeviceAssociation.swift
@@ -2,7 +2,7 @@ public struct DeviceAssociation: Codable, Sendable {
   public let token: String
   public let document: Document
   public let createdAt: String
-  /// ID token from backend; nil until backend sends it. Use placeholder when persisting if nil.
+  /// OIDC ID Token (JWT) when the backend client has an active secret; `nil` if omitted.
   public let idToken: String?
 
   public init(token: String, document: Document, createdAt: String, idToken: String? = nil) {

--- a/Sources/IDDigitalSDK/Data/Models/Record.swift
+++ b/Sources/IDDigitalSDK/Data/Models/Record.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+/// Payload for challenge execute/validate API. Use when backend supports it.
+typealias Record = [String: Any]

--- a/Sources/IDDigitalSDK/Data/Models/ValidationSession.swift
+++ b/Sources/IDDigitalSDK/Data/Models/ValidationSession.swift
@@ -2,4 +2,9 @@ struct ValidationSession: Codable, Sendable {
   let id: String
   let status: String
   let challenges: [Challenge]
+  /// Optional fields from API; aligned with Android for future use.
+  let type: String?
+  let createdAt: String?
+  let expirationDate: String?
+  let payload: [String: String]?
 }

--- a/Sources/IDDigitalSDK/Data/Network/KeycloakService.swift
+++ b/Sources/IDDigitalSDK/Data/Network/KeycloakService.swift
@@ -1,0 +1,81 @@
+import Foundation
+import FactoryKit
+
+final class KeycloakService {
+  @Injected(\.environment) private var environment
+  
+  private var keycloakBaseUrl: String {
+    switch environment {
+    case .staging:
+      return "https://bqm-keycloak-dev.alabamasolutions.com"
+    case .production:
+      return "https://bqm-keycloak.alabamasolutions.com"
+    }
+  }
+  
+  private func buildKeycloakUrl(realm: String, path: String) -> String {
+    return "\(keycloakBaseUrl)/realms/\(realm)/\(path)"
+  }
+  
+  func sendAuthenticationData(
+    tabId: String,
+    sessionCode: String,
+    clientId: String,
+    realm: String,
+    sdkToken: String
+  ) async throws -> String {
+    let urlString = buildKeycloakUrl(realm: realm, path: "protocol/openid-connect/token")
+    guard let url = URL(string: urlString) else {
+      throw IDDigitalError.unknown(cause: nil)
+    }
+    
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    
+    // Build form body
+    var components = URLComponents()
+    components.queryItems = [
+      URLQueryItem(name: "grant_type", value: "password"),
+      URLQueryItem(name: "session_code", value: sessionCode),
+      URLQueryItem(name: "tab_id", value: tabId),
+      URLQueryItem(name: "client_id", value: clientId),
+      URLQueryItem(name: "sdk_token", value: sdkToken)
+    ]
+    
+    // URLComponents creates query string, but we need form-encoded body
+    let formString = components.queryItems?.map { "\($0.name)=\($0.value ?? "")" }.joined(separator: "&") ?? ""
+    request.httpBody = formString.data(using: .utf8)
+    
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+      
+      guard let httpResponse = response as? HTTPURLResponse else {
+        throw IDDigitalError.unexpectedResponse(statusCode: -1, responseBody: nil)
+      }
+      
+      guard (200...299).contains(httpResponse.statusCode) else {
+        let responseBody = String(data: data, encoding: .utf8)
+        switch httpResponse.statusCode {
+        case 400, 404:
+          throw IDDigitalError.badResponse(statusCode: httpResponse.statusCode, responseBody: responseBody)
+        case 500...599:
+          throw IDDigitalError.serviceUnavailable(statusCode: httpResponse.statusCode, responseBody: responseBody)
+        default:
+          throw IDDigitalError.unexpectedResponse(statusCode: httpResponse.statusCode, responseBody: responseBody)
+        }
+      }
+      
+      guard let responseString = String(data: data, encoding: .utf8) else {
+        throw IDDigitalError.badResponse(statusCode: httpResponse.statusCode, responseBody: nil)
+      }
+      
+      return responseString
+    } catch {
+      if error is IDDigitalError {
+        throw error
+      }
+      throw error.toIDDigitalError()
+    }
+  }
+}

--- a/Sources/IDDigitalSDK/Data/Network/NetworkClient.swift
+++ b/Sources/IDDigitalSDK/Data/Network/NetworkClient.swift
@@ -12,6 +12,8 @@ protocol NetworkClient {
   func get<T: Decodable>(path: String) async throws -> T
   func post<T: Decodable>(path: String, body: some Encodable) async throws -> T
   func postAndExpectEmptyResponse(path: String, body: some Encodable) async throws
+  /// POST with JSON body from a dictionary. Returns raw response for endpoints that don't use ApiResponse envelope (e.g. challenge execute/validate).
+  func postWithJSONBody(path: String, body: [String: Any]) async throws -> (Data, HTTPURLResponse)
   func delete(path: String) async throws
 }
 
@@ -49,23 +51,31 @@ final class DefaultNetworkClient: NetworkClient {
   }
   
   func get<T: Decodable>(path: String) async throws -> T {
-    let (data, _) = try await makeRequest(path: path, method: "GET", body: EmptyBody())
-    
+    let (data, response) = try await makeRequest(path: path, method: "GET", body: EmptyBody())
     do {
       let apiResponse = try decoder.decode(ApiResponse<T>.self, from: data)
       return apiResponse.data
     } catch {
+      let raw = String(data: data, encoding: .utf8) ?? "(no string)"
+      #if DEBUG
+      print("[IDDigitalSDK] GET decode failed for \(response.url?.absoluteString ?? "?"): \(error.localizedDescription)")
+      print("[IDDigitalSDK] Raw response: \(raw.prefix(500))")
+      #endif
       throw IDDigitalError.badResponse(statusCode: -1, responseBody: "JSON decoding failed: \(error.localizedDescription)")
     }
   }
-  
+
   func post<T: Decodable>(path: String, body: some Encodable) async throws -> T {
-    let (data, _) = try await makeRequest(path: path, method: "POST", body: body)
-    
+    let (data, response) = try await makeRequest(path: path, method: "POST", body: body)
     do {
       let apiResponse = try decoder.decode(ApiResponse<T>.self, from: data)
       return apiResponse.data
     } catch {
+      let raw = String(data: data, encoding: .utf8) ?? "(no string)"
+      #if DEBUG
+      print("[IDDigitalSDK] POST decode failed for \(response.url?.absoluteString ?? "?"): \(error.localizedDescription)")
+      print("[IDDigitalSDK] Raw response: \(raw.prefix(500))")
+      #endif
       throw IDDigitalError.badResponse(statusCode: -1, responseBody: "JSON decoding failed: \(error.localizedDescription)")
     }
   }
@@ -73,62 +83,70 @@ final class DefaultNetworkClient: NetworkClient {
   func postAndExpectEmptyResponse(path: String, body: some Encodable) async throws {
     _ = try await makeRequest(path: path, method: "POST", body: body)
   }
-  
+
+  func postWithJSONBody(path: String, body: [String: Any]) async throws -> (Data, HTTPURLResponse) {
+    let bodyData = try JSONSerialization.data(withJSONObject: body)
+    return try await makeRequestRaw(path: path, method: "POST", bodyData: bodyData)
+  }
+
   func delete(path: String) async throws {
     _ = try await makeRequest(path: path, method: "DELETE", body: EmptyBody())
   }
   
   private func makeRequest(path: String, method: String, body: some Encodable) async throws -> (Data, HTTPURLResponse) {
+    let bodyData: Data? = (body is EmptyBody) ? nil : try encoder.encode(body)
+    let (data, httpResponse) = try await makeRequestRaw(path: path, method: method, bodyData: bodyData)
+    guard (200...299).contains(httpResponse.statusCode) else {
+      let responseBody = String(data: data, encoding: .utf8)
+      logNetworkError(url: httpResponse.url, method: method, statusCode: httpResponse.statusCode, responseBody: responseBody)
+      if let errorData = responseBody?.data(using: .utf8),
+         let errorResponse = try? decoder.decode(ErrorResponse.self, from: errorData) {
+        if errorResponse.code == "invalid-pin" {
+          throw IDDigitalError.invalidPin(reason: "Incorrect PIN")
+        }
+        if errorResponse.code == "too-many-attempts" {
+          throw IDDigitalError.tooManyAttempts
+        }
+      }
+      switch httpResponse.statusCode {
+      case 400, 404: throw IDDigitalError.badResponse(statusCode: httpResponse.statusCode, responseBody: responseBody)
+      case 500...599: throw IDDigitalError.serviceUnavailable(statusCode: httpResponse.statusCode, responseBody: responseBody)
+      default: throw IDDigitalError.unexpectedResponse(statusCode: httpResponse.statusCode, responseBody: responseBody)
+      }
+    }
+    return (data, httpResponse)
+  }
+
+  private func logNetworkError(url: URL?, method: String, statusCode: Int, responseBody: String?) {
+    #if DEBUG
+    let body = responseBody ?? "(empty)"
+    print("[IDDigitalSDK] HTTP \(statusCode) \(method) \(url?.absoluteString ?? "?")")
+    print("[IDDigitalSDK] Response: \(body)")
+    #endif
+  }
+
+  /// Raw request; caller interprets status (used for challenge execute/validate).
+  private func makeRequestRaw(path: String, method: String, bodyData: Data?) async throws -> (Data, HTTPURLResponse) {
     guard let url = URL(string: "\(baseUrl)/\(path)") else {
       throw IDDigitalError.unknown(cause: nil)
     }
-    
     var request = URLRequest(url: url)
     request.httpMethod = method
     request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
-    
     if let apiKey = self.apiKey {
       request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
     }
-    
     let fingerprint = await deviceIdentifierProvider.getDeviceFingerprint()
     request.setValue(fingerprint, forHTTPHeaderField: "x-device-fingerprint")
-    
     if let association = await deviceAssociationStorage.get() {
       request.setValue("Bearer \(association.token)", forHTTPHeaderField: "Authorization")
     }
-    
-    if !(body is EmptyBody) {
-      request.httpBody = try encoder.encode(body)
-    }
-    
+    request.httpBody = bodyData
     do {
       let (data, response) = try await urlSession.data(for: request)
-      
       guard let httpResponse = response as? HTTPURLResponse else {
         throw IDDigitalError.unexpectedResponse(statusCode: -1, responseBody: nil)
       }
-      
-      guard (200...299).contains(httpResponse.statusCode) else {
-        let responseBody = String(data: data, encoding: .utf8)
-        if let errorData = responseBody?.data(using: .utf8),
-           let errorResponse = try? decoder.decode(ErrorResponse.self, from: errorData) {
-          if errorResponse.code == "invalid-pin" {
-            throw IDDigitalError.invalidPin(reason: "Incorrect PIN")
-          }
-          if errorResponse.code == "too-many-attempts" {
-            throw IDDigitalError.tooManyAttempts
-          }
-        }
-        
-        
-        switch httpResponse.statusCode {
-        case 400, 404: throw IDDigitalError.badResponse(statusCode: httpResponse.statusCode, responseBody: responseBody)
-        case 500...599: throw IDDigitalError.serviceUnavailable(statusCode: httpResponse.statusCode, responseBody: responseBody)
-        default: throw IDDigitalError.unexpectedResponse(statusCode: httpResponse.statusCode, responseBody: responseBody)
-        }
-      }
-      
       return (data, httpResponse)
     } catch {
       if error is IDDigitalError { throw error }

--- a/Sources/IDDigitalSDK/Data/Network/ValidationSessionService.swift
+++ b/Sources/IDDigitalSDK/Data/Network/ValidationSessionService.swift
@@ -1,3 +1,4 @@
+import Foundation
 import FactoryKit
 
 final class ValidationSessionService {
@@ -60,5 +61,50 @@ final class ValidationSessionService {
     
     let response: ValidationSession = try await networkClient.post(path: "validations/", body: body)
     return response
+  }
+
+  // MARK: - Challenge execute/validate (for when backend supports them; not exposed in public API yet)
+
+  func executeChallenge(challengeId: String, data: Record) async throws {
+    let (responseData, response) = try await networkClient.postWithJSONBody(
+      path: "challenges/\(challengeId)/execute/",
+      body: data
+    )
+    guard (200...299).contains(response.statusCode) else {
+      let responseBody = String(data: responseData, encoding: .utf8)
+      switch response.statusCode {
+      case 400, 404: throw IDDigitalError.badResponse(statusCode: response.statusCode, responseBody: responseBody)
+      case 500...599: throw IDDigitalError.serviceUnavailable(statusCode: response.statusCode, responseBody: responseBody)
+      default: throw IDDigitalError.unexpectedResponse(statusCode: response.statusCode, responseBody: responseBody)
+      }
+    }
+  }
+
+  func validateChallenge(challengeId: String, data: Record) async throws -> Bool {
+    let (responseData, response) = try await networkClient.postWithJSONBody(
+      path: "challenges/\(challengeId)/validate/",
+      body: data
+    )
+    if (200...299).contains(response.statusCode) {
+      return true
+    }
+    let responseBody = String(data: responseData, encoding: .utf8)
+    if response.statusCode == 400 || response.statusCode == 404 {
+      let decoder = JSONDecoder()
+      decoder.keyDecodingStrategy = .convertFromSnakeCase
+      if let errorResponse = try? decoder.decode(ErrorResponse.self, from: responseData) {
+        if errorResponse.code == "invalid-pin" {
+          return false
+        }
+        if errorResponse.code == "too-many-attempts" {
+          throw IDDigitalError.tooManyAttempts
+        }
+      }
+      throw IDDigitalError.badResponse(statusCode: response.statusCode, responseBody: responseBody)
+    }
+    if (500...599).contains(response.statusCode) {
+      throw IDDigitalError.serviceUnavailable(statusCode: response.statusCode, responseBody: responseBody)
+    }
+    throw IDDigitalError.unexpectedResponse(statusCode: response.statusCode, responseBody: responseBody)
   }
 }

--- a/Sources/IDDigitalSDK/FlowCoordinators/DeviceAssociationCoordinator.swift
+++ b/Sources/IDDigitalSDK/FlowCoordinators/DeviceAssociationCoordinator.swift
@@ -32,21 +32,9 @@ final class DeviceAssociationCoordinator {
     let newDeviceAssociation = try await completeAssociationUseCase.execute(id: validationSession.id)
     
     try await IDDigitalSDK.shared.removeAssociation()
-    
-    // TODO: Remover cuando el backend envíe idToken correctamente
-    let associationToSave: DeviceAssociation
-    if let idToken = newDeviceAssociation.idToken {
-      associationToSave = newDeviceAssociation
-    } else {
-      associationToSave = DeviceAssociation(
-        token: newDeviceAssociation.token,
-        document: newDeviceAssociation.document,
-        createdAt: newDeviceAssociation.createdAt,
-        idToken: "TEMP_ID_TOKEN_PENDING_BACKEND"
-      )
-    }
+
     let storage = Container.shared.deviceAssociationStorage()
-    await storage.save(association: associationToSave)
+    await storage.save(association: newDeviceAssociation)
     
     if let result = pinResult, result.saveBiometrics {
       let pinManager = Container.shared.pinDataStoreManager()
@@ -56,8 +44,8 @@ final class DeviceAssociationCoordinator {
     try await presentSuccess()
     navigationController?.dismiss(animated: true)
     
-    // TODO: Remover cuando el backend envíe idToken correctamente
-    return newDeviceAssociation.idToken ?? "TEMP_ID_TOKEN_PENDING_BACKEND"
+    // JWT from backend when the SDK client has an active secret; empty if omitted/null.
+    return newDeviceAssociation.idToken ?? ""
   }
   
   private func startDeviceAssociation() async throws -> ValidationSession {

--- a/Sources/IDDigitalSDK/FlowCoordinators/DeviceAssociationCoordinator.swift
+++ b/Sources/IDDigitalSDK/FlowCoordinators/DeviceAssociationCoordinator.swift
@@ -33,8 +33,20 @@ final class DeviceAssociationCoordinator {
     
     try await IDDigitalSDK.shared.removeAssociation()
     
+    // TODO: Remover cuando el backend envíe idToken correctamente
+    let associationToSave: DeviceAssociation
+    if let idToken = newDeviceAssociation.idToken {
+      associationToSave = newDeviceAssociation
+    } else {
+      associationToSave = DeviceAssociation(
+        token: newDeviceAssociation.token,
+        document: newDeviceAssociation.document,
+        createdAt: newDeviceAssociation.createdAt,
+        idToken: "TEMP_ID_TOKEN_PENDING_BACKEND"
+      )
+    }
     let storage = Container.shared.deviceAssociationStorage()
-    await storage.save(association: newDeviceAssociation)
+    await storage.save(association: associationToSave)
     
     if let result = pinResult, result.saveBiometrics {
       let pinManager = Container.shared.pinDataStoreManager()
@@ -44,7 +56,8 @@ final class DeviceAssociationCoordinator {
     try await presentSuccess()
     navigationController?.dismiss(animated: true)
     
-    return newDeviceAssociation.token
+    // TODO: Remover cuando el backend envíe idToken correctamente
+    return newDeviceAssociation.idToken ?? "TEMP_ID_TOKEN_PENDING_BACKEND"
   }
   
   private func startDeviceAssociation() async throws -> ValidationSession {

--- a/Sources/IDDigitalSDK/IDDigitalSDK.swift
+++ b/Sources/IDDigitalSDK/IDDigitalSDK.swift
@@ -10,20 +10,19 @@ public final actor IDDigitalSDK {
   
   private init() {}
   
-  public func initialize(apiKey: String, environment: IDDigitalSDKEnvironment) {
-    
+  public func initialize(
+    apiKey: String,
+    environment: IDDigitalSDKEnvironment,
+    cognitoAppClientIdOverride: String? = nil
+  ) async throws {
     guard !isInitialized else {
       print("IDDigitalSDK has already been initialized.")
       return
     }
-    
     Container.shared.apiKey.register { apiKey }
     Container.shared.environment.register { environment }
-    
-    Task {
-      await AmplifyInitializer.initialize()
-    }
-    
+    Container.shared.cognitoAppClientIdOverride.register { cognitoAppClientIdOverride }
+    try await AmplifyInitializer.initialize()
     self.isInitialized = true
     print("IDDigitalSDK initialized successfully.")
   }
@@ -66,6 +65,12 @@ public final actor IDDigitalSDK {
     return association != nil
   }
   
+  public func getDeviceAssociation() async throws -> DeviceAssociation? {
+    try ensureInitialized()
+    let storage = Container.shared.deviceAssociationStorage()
+    return await storage.get()
+  }
+  
   public func removeAssociation() async {
     do {
       let useCase = Container.shared.removeAssociationUseCase()
@@ -90,5 +95,27 @@ public final actor IDDigitalSDK {
     )
     
     try await coordinator.start()
+  }
+  
+  public func sendToKeycloak(
+    tabId: String,
+    sessionCode: String,
+    clientId: String,
+    realm: String,
+    sdkToken: String
+  ) async throws -> String {
+    try ensureInitialized()
+    do {
+      let keycloakService = Container.shared.keycloakService()
+      return try await keycloakService.sendAuthenticationData(
+        tabId: tabId,
+        sessionCode: sessionCode,
+        clientId: clientId,
+        realm: realm,
+        sdkToken: sdkToken
+      )
+    } catch {
+      throw error.toIDDigitalError()
+    }
   }
 }

--- a/Sources/IDDigitalSDK/IDDigitalSDK.swift
+++ b/Sources/IDDigitalSDK/IDDigitalSDK.swift
@@ -46,6 +46,7 @@ public final actor IDDigitalSDK {
   }
   
   
+  /// Completes device association and returns the ID token JWT, or an empty string if the backend did not include one.
   @MainActor
   public func associate(from presentingViewController: UIViewController, document: Document) async throws -> String {
     try await ensureInitialized()
@@ -97,6 +98,7 @@ public final actor IDDigitalSDK {
     try await coordinator.start()
   }
   
+  /// Sends the OIDC **ID token** (JWT from `DeviceAssociation.idToken`) to Keycloak as `sdk_token`.
   public func sendToKeycloak(
     tabId: String,
     sessionCode: String,


### PR DESCRIPTION
## Summary
This branch completes the device-association flow so the client app receives a real **OIDC ID token (JWT)** from the backend (when the SDK client has an active secret), persists it correctly, and sends it to **Keycloak** as `sdk_token`—without relying on placeholder strings. 

The native POC apps are now aligned on using the **ID token** versus the opaque association token and have been updated to avoid logging sensitive secrets.

---

## Changes

* **Persistence:** Now persists the `DeviceAssociation` object exactly as returned by the API, removing synthetic ID token placeholders.
* **API Methods:** `associate(...)` returns the JWT or an empty string if the backend omits the `idToken`.
* **Keycloak Integration:** Documented that `sdkToken` is the OIDC JWT from `DeviceAssociation.idToken`.
* **General:** Includes earlier commits related to Keycloak integration and flow alignment.

---

## Impact
- **Security:** Removed placeholder strings and prevented the logging of secrets in POC implementations.
- **Consistency:** Standardized the handoff between the SDK and Keycloak across both mobile platforms.
- **Backward Compatibility:** Handled legacy token flags to ensure a smooth transition during local data migrations.


